### PR TITLE
Require cl

### DIFF
--- a/inf-ruby.el
+++ b/inf-ruby.el
@@ -33,6 +33,9 @@
 (require 'compile)
 (require 'ruby-mode)
 
+(eval-when-compile
+  (require 'cl))
+
 (defvar inf-ruby-default-implementation "ruby"
   "Which ruby implementation to use if none is specified.")
 


### PR DESCRIPTION
Various macros used here such as setf and case may not be defined unless
cl is loaded.  Loading it with eval-when-compile is the preferred
practice for Emacs libraries to use cl's macros, as far as I know (see
http://www.gnu.org/software/emacs/manual/html_node/cl/Overview.html and
http://www.emacswiki.org/emacs/CommonLispForEmacs).

I ran into this when I did emacs --batch -f batch-byte-compile and then loaded this library: the result would not run for lack of the setf macro being available at compile time.
