### PR TITLE
Remove "--inf-ruby-mode" argument, we already handle continuation prompt

### DIFF
--- a/inf-ruby.el
+++ b/inf-ruby.el
@@ -54,10 +54,10 @@
   "*Mode map for inf-ruby-mode")
 
 (defvar inf-ruby-implementations
-  '(("ruby"     . "irb --inf-ruby-mode -r irb/completion")
+  '(("ruby"     . "irb -r irb/completion")
     ("jruby"    . "jruby -S irb -r irb/completion")
     ("rubinius" . "rbx -r irb/completion")
-    ("yarv"     . "irb1.9 --inf-ruby-mode -r irb/completion")) ;; TODO: ironruby?
+    ("yarv"     . "irb1.9 -r irb/completion")) ;; TODO: ironruby?
   "An alist of ruby implementations to irb executable names.")
 
 ;; TODO: do we need these two defvars?
@@ -155,7 +155,7 @@ Defaults to a regexp ignoring all inputs of 0, 1, or 2 letters.")
 (defun inf-ruby-output-filter (output)
   "Check if the current prompt is a top-level prompt"
   (setq inf-ruby-at-top-level-prompt-p
-        (string-match inf-ruby-prompt-pattern
+        (string-match inf-ruby-first-prompt-pattern
                       (car (last (split-string output "\n"))))))
 
 ;; adapted from replace-in-string in XEmacs (subr.el)


### PR DESCRIPTION
AFAICT, the difference between `inf-ruby-first-prompt-pattern` and `inf-ruby-prompt-pattern` is meant to handle the continuation prompt (the one we see after an unfinished expression or unclosed literal).
Moreover, we're already not passing this argument to at least one of the four implementations (jruby, not sure about rbx defaults).

Pro:
You always see something after pressing RET. Seeing lots of whitespace instead isn't too helpful, especially if the repl has something running in another thread that sometimes prints to stdout.

Con:
[Pickaxe says](http://www.rubycentral.org/pickaxe/irb.html) that in addition to modifying the prompt, `--inf-ruby-mode` suppresses Readline. I tried both `--readline` and `--noreadline`, and couldn't find any difference with the latest Emacs. Maybe we'd have to pass `--noreadline` for older Emacsen. I suggest make the change and see if anyone complains.

Meh:
There's no difference in input history. You'd think that continued expressions would be single entries in history before this change, but no: each time you press RET - separate entry.
