### PR TITLE
Use ruby-backward-sexp

### DIFF
--- a/inf-ruby.el
+++ b/inf-ruby.el
@@ -269,7 +269,7 @@ Must not contain ruby meta characters.")
 (defun ruby-send-last-sexp ()
   "Send the previous sexp to the inferior Ruby process."
   (interactive)
-  (ruby-send-region (save-excursion (backward-sexp) (point)) (point)))
+  (ruby-send-region (save-excursion (ruby-backward-sexp) (point)) (point)))
 
 (defun ruby-send-block ()
   "Send the current block to the inferior Ruby process."


### PR DESCRIPTION
ruby-mode doesn't customize forward-sexp-function, but it does have its own forward/backward-sexp commands.

With this change, you can put point after a class definition or after the end of a do/end block, press `C-x C-e`, and it will send the whole definition or block to the repl.
