### PR TITLE
Facilitating creation of an inferior process running rails console instead of irb

### DIFF
--- a/inf-ruby.el
+++ b/inf-ruby.el
@@ -55,6 +55,10 @@
     ("jruby"    . "jruby -S irb -r irb/completion")
     ("rubinius" . "rbx -r irb/completion")
     ("rails"    . "rails c")
+    ;; This will be optionally invoked by the user 
+    ;; and it will be the user's responsibility to ensure that
+    ;; emacs' current directory is a rails app root, else
+    ;; the user will get a message about rails usage.
     ("yarv"     . "irb1.9 --inf-ruby-mode -r irb/completion")) ;; TODO: ironruby?
   "An alist of ruby implementations to irb executable names.")
 


### PR DESCRIPTION
Hello

With inf-ruby, we can run irb as a subprocess and I can see that for various ruby implementations you have added the corresponding irb commands. However, most rails developers use the rails console more often than irb. Also, given that rails console is a superset of irb, I thought of adding rails console to the list. So, essentially it will be treated as another irb implementation.

This of course has one drawback and that is the fact that for rails console to load successfully the current directory of emacs has to the root of a rails application. I believe this should not be a pain for most rails developers as they usually work with their app root as their current directory. However, this has to set by the user using M-x cd unless emacs is started from that directory.

Your ideas and comments are welcome.

Thanks,
Amitav
