### PR TITLE
Keybindings for enh-ruby-mode, too

### DIFF
--- a/inf-ruby.el
+++ b/inf-ruby.el
@@ -91,6 +91,21 @@ next one.")
   (define-key ruby-mode-map "\C-c\C-l" 'ruby-load-file)
   (define-key ruby-mode-map "\C-c\C-s" 'inf-ruby))
 
+;;;###autoload
+(defun inf-enh-ruby-setup-keybindings ()
+  "Set local key defs to invoke inf-ruby from ruby-mode."
+  (define-key enh-ruby-mode-map "\M-\C-x" 'ruby-send-definition)
+  (define-key enh-ruby-mode-map "\C-x\C-e" 'ruby-send-last-sexp)
+  (define-key enh-ruby-mode-map "\C-c\C-b" 'ruby-send-block)
+  (define-key enh-ruby-mode-map "\C-c\M-b" 'ruby-send-block-and-go)
+  (define-key enh-ruby-mode-map "\C-c\C-x" 'ruby-send-definition)
+  (define-key enh-ruby-mode-map "\C-c\M-x" 'ruby-send-definition-and-go)
+  (define-key enh-ruby-mode-map "\C-c\C-r" 'ruby-send-region)
+  (define-key enh-ruby-mode-map "\C-c\M-r" 'ruby-send-region-and-go)
+  (define-key enh-ruby-mode-map "\C-c\C-z" 'ruby-switch-to-inf)
+  (define-key enh-ruby-mode-map "\C-c\C-l" 'ruby-load-file)
+  (define-key enh-ruby-mode-map "\C-c\C-s" 'inf-ruby))
+
 (defvar inf-ruby-buffer nil "Current irb process buffer.")
 
 (defun inf-ruby-mode ()
@@ -370,6 +385,10 @@ Module used by readline when running irb through a terminal"
 ;;;###autoload
 (eval-after-load 'ruby-mode
   '(inf-ruby-setup-keybindings))
+
+;;;###autoload
+(eval-after-load 'enh-ruby-mode
+  '(inf-enh-ruby-setup-keybindings))
 
 (provide 'inf-ruby)
 ;;; inf-ruby.el ends here


### PR DESCRIPTION
This patch makes the keybindings work in enhanced-ruby-mode. 
The patch is rough because of ugly duplication, but the idea is that inf-ruby should work with other modes aside of ruby-mode. So maybe this is a start of a discussion.
