### PR TITLE
Added macruby to inf-ruby-implementations

### DIFF
--- a/inf-ruby.el
+++ b/inf-ruby.el
@@ -54,7 +54,8 @@
   '(("ruby"     . "irb --inf-ruby-mode -r irb/completion")
     ("jruby"    . "jruby -S irb -r irb/completion")
     ("rubinius" . "rbx -r irb/completion")
-    ("yarv"     . "irb1.9 --inf-ruby-mode -r irb/completion")) ;; TODO: ironruby?
+    ("yarv"     . "irb1.9 --inf-ruby-mode -r irb/completion")
+    ("macruby"  . "macirb -r irb/completion")) ;; TODO: ironruby?
   "An alist of ruby implementations to irb executable names.")
 
 ;; TODO: do we need these two defvars?


### PR DESCRIPTION
Needs its own entry as macirb doesn't support the --inf-ruby-mode option.
