### PR TITLE
Changed 'bundle exec irb' to 'bundle console'

### DIFF
--- a/inf-ruby.el
+++ b/inf-ruby.el
@@ -534,7 +534,7 @@ Gemfile, it should use the `gemspec' instruction."
      ((file-exists-p "console.rb")
       (run-ruby "ruby console.rb" "console.rb"))
      (t
-      (run-ruby "bundle exec irb")))))
+      (run-ruby "bundle console")))))
 
 ;;;###autoload (inf-ruby-setup-keybindings)
 


### PR DESCRIPTION
It pre-load gems in the following case.

Gemfile

``` ruby
source "https://rubygems.org"

gem "i18n"
gem "active_support", :require => 'active_support/core_ext'
```

Inf-Ruby:run

```
irb(main):001:0> 1.day
=> 1 day
```
