### PR TITLE
Avoid error when trying to switch to non-existent inf-ruby buffer

### DIFF
--- a/inf-ruby.el
+++ b/inf-ruby.el
@@ -321,7 +321,7 @@ Must not contain ruby meta characters.")
   "Switch to the ruby process buffer.
 With argument, positions cursor at end of buffer."
   (interactive "P")
-  (if (get-buffer inf-ruby-buffer)
+  (if (and inf-ruby-buffer (get-buffer inf-ruby-buffer))
       (pop-to-buffer inf-ruby-buffer)
     (error "No current process buffer. See variable inf-ruby-buffer."))
   (cond (eob-p


### PR DESCRIPTION
Running `ruby-switch-to-inf` when there is no `inf-ruby-buffer` produces a hard error due to passing `nil` to `get-buffer`. This commit makes the handling of this case more robust.
