### PR TITLE
fix PAGER setting

### DIFF
--- a/inf-ruby.el
+++ b/inf-ruby.el
@@ -282,7 +282,7 @@ If there is a process already running in `*ruby*', switch to that buffer.
       (let ((commandlist (split-string-and-unquote command))
             (process-environment process-environment))
         ;; http://debbugs.gnu.org/15775
-        (setenv "PAGER" (executable-find "cat"))
+        (setenv "PAGER" "cat")
         (set-buffer (apply 'make-comint name (car commandlist)
                            nil (cdr commandlist)))
         (inf-ruby-mode)))


### PR DESCRIPTION
Setting PAGER to (executable-find "cat") does not work on my system (OSX 10.9/tmux 1.8/bash 3.2.51/emacs 24.3.1), for a rails 3.2.15 project using hirb 0.7.1 on the console.  I have 'export PAGER="less"' in my .bashrc (which I use on systems running several different *NIX variants)

The error results from the console producing: 

WARNING: terminal is not fully functional
-  (press RETURN)

on any input; thus any attempt to pass anything to the console without an extra RETURN will hang.

_ANY_ of the following in inf-ruby.el will result in this error:

(setenv "PAGER" "/bin/cat")
;; yes, /bin/cat _does_ exist on the system...

(setenv "PAGER" (executable-find "cat"))
;; (executable-find "cat") evaluates to "/bin/cat"

(setenv "PAGER" nil)
;; which unsets PAGER

(setenv "PAGER")
;; which also unsets PAGER

The _only_ PAGER setting I've been able to find that works is "cat".
