### PR TITLE
Fix deprecation warnings (#40)

### DIFF
--- a/inf-ruby.el
+++ b/inf-ruby.el
@@ -134,7 +134,6 @@ next one.")
   '(("SyntaxError: \\(?:compile error\n\\)?\\([^\(].*\\):\\([1-9][0-9]*\\):" 1 2)
     ("^\tfrom \\([^\(].*\\):\\([1-9][0-9]*\\)\\(:in `.*'\\)?$" 1 2)))
 
-;;;###autoload
 (defun inf-ruby-setup-keybindings ()
   "Hook up `inf-ruby-minor-mode' to each of `ruby-source-modes'."
   (warn "`inf-ruby-setup-keybindings' is deprecated, please don't use it anymore.")


### PR DESCRIPTION
`inf-ruby-setup-keybindings' is deprecated, but was still being
marked for autoload, thereby triggering the deprecation warning.

Fixes #40.
