### PR TITLE
Bind C-c C-c to 'inf-ruby-console-auto

### DIFF
--- a/inf-ruby.el
+++ b/inf-ruby.el
@@ -165,6 +165,7 @@ next one.")
     (define-key map (kbd "C-c C-z") 'ruby-switch-to-inf)
     (define-key map (kbd "C-c C-l") 'ruby-load-file)
     (define-key map (kbd "C-c C-s") 'inf-ruby)
+    (define-key map (kbd "C-c C-c") 'inf-ruby-console-auto)
     map))
 
 ;;;###autoload


### PR DESCRIPTION
Would be very handy for Rails developers, for example. The second 'c' is a mnemonic for 'console'.
