### PR TITLE
Update inf-ruby.el

### DIFF
--- a/inf-ruby.el
+++ b/inf-ruby.el
@@ -82,7 +82,7 @@ Also see the description of `ielm-prompt-read-only'."
   :group 'inf-ruby)
 
 (defcustom inf-ruby-implementations
-  '(("ruby"     . "irb --prompt default --noreadline -r irb/completion")
+  '(("ruby"     . "irb --prompt default --noreadline -r irb/completion -EUTF-8")
     ("jruby"    . "jruby -S irb --prompt default --noreadline -r irb/completion")
     ("rubinius" . "rbx -r irb/completion")
     ("yarv"     . "irb1.9 -r irb/completion")


### PR DESCRIPTION
I added utf-8 argument for inf-ruby-inplementations: “ruby irb”

Since utf-8 encoding is now the default with ruby 2.0 and utf-8 becoming a more and more widely adopted default. It seems a good idea to me.
