### PR TITLE
Automatically entering inf-ruby on pry

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ automatically.
 Additionally, consider adding
 
 ```lisp
-(add-hook 'compilation-filter-hook 'inf-ruby-auto-enter)
+(inf-ruby-setup-auto-breakpoint)
 ```
 
 to your init file to automatically switch from common Ruby compilation

--- a/README.md
+++ b/README.md
@@ -60,10 +60,10 @@ automatically.
 Additionally, consider adding
 
 ```lisp
-(add-hook 'after-init-hook 'inf-ruby-switch-setup)
+(add-hook 'compilation-filter-hook 'inf-ruby-auto-enter)
 ```
 
-to your init file to easily switch from common Ruby compilation
+to your init file to automatically switch from common Ruby compilation
 modes to interact with a debugger.
 
 ### Emacs Prelude

--- a/inf-ruby.el
+++ b/inf-ruby.el
@@ -634,6 +634,9 @@ keymaps to bind `inf-ruby-switch-from-compilation' to `С-x C-q'."
 one of the predicates matches, then calls `inf-ruby-console-NAME',
 passing it the found directory.")
 
+(defvar inf-ruby-breakpoint-pattern "\\[1\\] pry(" "Pattern to check if the
+current line indicates the current compilation mode entered a breakpoint")
+
 (defun inf-ruby-console-match (dir)
   "Find matching console command for DIR, if any."
   (catch 'type
@@ -730,6 +733,13 @@ Gemfile, it should use the `gemspec' instruction."
   (interactive "D")
   (let ((default-directory (file-name-as-directory dir)))
     (run-ruby "bundle exec racksh" "racksh")))
+
+(defun inf-ruby-auto-enter ()
+  "Automatically enters inf-ruby mode when it sees a breakpoint-indicating pattern."
+  (when (member major-mode '(rspec-compilation-mode ruby-compilation-mode projectile-rails-server-mode))
+    (beginning-of-line)
+    (when (re-search-forward inf-ruby-breakpoint-pattern (line-end-position) t)
+      (inf-ruby-switch-from-compilation))))
 
 ;;;###autoload
 (defun inf-ruby-console-default (dir)

--- a/inf-ruby.el
+++ b/inf-ruby.el
@@ -634,8 +634,9 @@ keymaps to bind `inf-ruby-switch-from-compilation' to `С-x C-q'."
 one of the predicates matches, then calls `inf-ruby-console-NAME',
 passing it the found directory.")
 
-(defvar inf-ruby-breakpoint-pattern "\\[1\\] pry(" "Pattern to check if the
-current line indicates the current compilation mode entered a breakpoint")
+(defvar inf-ruby-breakpoint-pattern "\\(\\[1\\] pry(\\)\\|\\((rdb:1)\\)"
+  "Pattern to check if the current line indicates the current compilation mode
+entered a breakpoint")
 
 (defun inf-ruby-console-match (dir)
   "Find matching console command for DIR, if any."

--- a/inf-ruby.el
+++ b/inf-ruby.el
@@ -635,8 +635,8 @@ one of the predicates matches, then calls `inf-ruby-console-NAME',
 passing it the found directory.")
 
 (defvar inf-ruby-breakpoint-pattern "\\(\\[1\\] pry(\\)\\|\\((rdb:1)\\)"
-  "Pattern to check if the current line indicates the current compilation mode
-entered a breakpoint")
+  "Pattern found when a breakpoint is triggered in a compilation session.
+This checks if the current line is a pry or ruby-debug prompt.")
 
 (defun inf-ruby-console-match (dir)
   "Find matching console command for DIR, if any."
@@ -736,7 +736,7 @@ Gemfile, it should use the `gemspec' instruction."
     (run-ruby "bundle exec racksh" "racksh")))
 
 (defmacro in-ruby-compilation-modes (mode-var &rest body)
-  "Checks if we're in a ruby compilation mode, and runs BODY in an
+  "Checks if MODE-VAR is a ruby compilation mode, and runs BODY in an
 implicit progn if t."
   `(when (member ,mode-var '(rspec-compilation-mode
                               ruby-compilation-mode

--- a/inf-ruby.el
+++ b/inf-ruby.el
@@ -634,7 +634,7 @@ keymaps to bind `inf-ruby-switch-from-compilation' to `С-x C-q'."
 one of the predicates matches, then calls `inf-ruby-console-NAME',
 passing it the found directory.")
 
-(defvar inf-ruby-breakpoint-pattern ".*\\(\\[1\\] pry(\\)\\|\\((rdb:1)\\)"
+(defvar inf-ruby-breakpoint-pattern "\\(\\[1\\] pry(\\)\\|\\((rdb:1)\\)"
   "Pattern found when a breakpoint is triggered in a compilation session.
 This checks if the current line is a pry or ruby-debug prompt.")
 
@@ -746,7 +746,8 @@ Gemfile, it should use the `gemspec' instruction."
   (when (inf-ruby-in-ruby-compilation-modes major-mode)
     (save-excursion
       (beginning-of-line)
-      (when (looking-at inf-ruby-breakpoint-pattern)
+      (when (re-search-forward inf-ruby-breakpoint-pattern
+                               (line-end-position) t)
         (inf-ruby-switch-from-compilation)))))
 
 (defun inf-ruby-auto-exit (input)

--- a/inf-ruby.el
+++ b/inf-ruby.el
@@ -736,13 +736,13 @@ Gemfile, it should use the `gemspec' instruction."
     (run-ruby "bundle exec racksh" "racksh")))
 
 (defun inf-ruby-in-ruby-compilation-modes (mode-var)
-  "Checks if MODE-VAR is a ruby compilation mode"
+  "Check if MODE-VAR is a ruby compilation mode"
   (member mode-var '(rspec-compilation-mode
                      ruby-compilation-mode
                      projectile-rails-server-mode)))
 
 (defun inf-ruby-auto-enter ()
-  "Automatically enters inf-ruby mode when it sees a breakpoint-indicating pattern."
+  "Automatically enter inf-ruby mode if the breakpoint pattern matches the current line."
   (when (inf-ruby-in-ruby-compilation-modes major-mode)
     (save-excursion
       (beginning-of-line)
@@ -751,8 +751,7 @@ Gemfile, it should use the `gemspec' instruction."
         (inf-ruby-switch-from-compilation)))))
 
 (defun inf-ruby-auto-exit (input)
-  "Checks if the current input is a debugger exit command and returns
-to the previous compilation mode if t."
+  "Check the current input is a debugger exit command and return to the previous compilation mode if t."
   (when (inf-ruby-in-ruby-compilation-modes inf-ruby-orig-compilation-mode)
     (if (member input '("quit" "exit" ""))
         (inf-ruby-maybe-switch-to-compilation))))

--- a/inf-ruby.el
+++ b/inf-ruby.el
@@ -753,7 +753,7 @@ Gemfile, it should use the `gemspec' instruction."
   "Checks if the current input is a debugger exit command and returns
 to the previous compilation mode if t."
   (when (inf-ruby-in-ruby-compilation-modes inf-ruby-orig-compilation-mode)
-    (if (member input '("quit" "exit"))
+    (if (member input '("quit" "exit" ""))
         (inf-ruby-maybe-switch-to-compilation))))
 
 (defun inf-ruby-setup-auto-breakpoint ()


### PR DESCRIPTION
This allows the user to add

```lisp
(add-hook 'compilation-filter-hook 'inf-ruby-auto-enter)
```

and automatically enter `inf-ruby` at a breakpoint. Currently it only supports the Pry debug pattern, but could support more if needed.