### PR TITLE
Fix ruby-send-definition

### DIFF
--- a/inf-ruby.el
+++ b/inf-ruby.el
@@ -393,7 +393,7 @@ Must not contain ruby meta characters.")
   "Send the current definition to the inferior Ruby process."
   (interactive)
   (save-excursion
-    (ruby-end-of-defun)
+    (end-of-defun)
     (let ((end (point)))
       (ruby-beginning-of-defun)
       (ruby-send-region (point) end))))


### PR DESCRIPTION
The `ruby-end-of-defun` function doesn't work on it's own (for me at least), but is called by `end-of-defun` according to it's description:
> Move point to the end of the current defun.
> The defun begins at or after the point.  This function is called
> by `end-of-defun'.


### Test case:
```
def test
|
end
```

*Expected*: Definition is send to irb.

*Actual*: `Scan error: "Containing expression ends prematurely", 14, 14`