### PR TITLE
Allow single quoted gemspec name

### DIFF
--- a/inf-ruby.el
+++ b/inf-ruby.el
@@ -709,7 +709,7 @@ Gemfile, it should use the `gemspec' instruction."
                 "bundle exec irb -I lib")
             "irb -I lib"))
          (name (inf-ruby-file-contents-match
-                gemspec "\\.name[ \t]*=[ \t]*\"\\([^\"]+\\)\"" 1))
+                gemspec "\\.name[ \t]*=[ \t]*[\'\"]\\([^\"\n]+\\)[\'\"]" 1))
          args files)
     (unless (file-exists-p "lib")
       (error "The directory must contain a 'lib' subdirectory"))

--- a/inf-ruby.el
+++ b/inf-ruby.el
@@ -709,7 +709,7 @@ Gemfile, it should use the `gemspec' instruction."
                 "bundle exec irb -I lib")
             "irb -I lib"))
          (name (inf-ruby-file-contents-match
-                gemspec "\\.name[ \t]*=[ \t]*[\'\"]\\([^\"\n]+\\)[\'\"]" 1))
+                gemspec "\\.name[ \t]*=[ \t]*['\"]\\([^'\"]+\\)['\"]" 1))
          args files)
     (unless (file-exists-p "lib")
       (error "The directory must contain a 'lib' subdirectory"))


### PR DESCRIPTION
Many people use single quotes unless interpolating in Ruby projects. 

For gems the function `inf-ruby-console-gem` was failing to match `name` and as a result not requiring `lib/name.rb` on invocation of `irb`. 

References:
- http://guides.rubygems.org/specification-reference/
- http://anti-pattern.com/always-use-double-quoted-strings-in-ruby