### PR TITLE
Add support for zeus console

### DIFF
--- a/inf-ruby.el
+++ b/inf-ruby.el
@@ -630,7 +630,8 @@ keymaps to bind `inf-ruby-switch-from-compilation' to `С-x C-q'."
        'inf-ruby-switch-from-compilation)))
 
 (defvar inf-ruby-console-patterns-alist
-  '((inf-ruby-console-rails-p . rails)
+  '((".zeus.sock" . zeus)
+    (inf-ruby-console-rails-p . rails)
     ("*.gemspec" . gem)
     (inf-ruby-console-racksh-p . racksh)
     ("Gemfile" . default))
@@ -657,7 +658,7 @@ This checks if the current line is a pry or ruby-debug prompt.")
 ;;;###autoload
 (defun inf-ruby-console-auto ()
   "Run the appropriate Ruby console command.
-The command and and the directory to run it from are detected
+The command and the directory to run it from are detected
 automatically."
   (interactive)
   (let* ((dir (locate-dominating-file default-directory
@@ -673,6 +674,13 @@ automatically."
        (file-exists-p "config/application.rb")
        (inf-ruby-file-contents-match "config/application.rb"
                                      "\\_<Rails::Application\\_>")))
+
+;;;###autoload
+(defun inf-ruby-console-zeus (dir)
+  (interactive "D")
+  (let ((default-directory (file-name-as-directory dir))
+        (exec-prefix (if (executable-find "zeus") "" "bundle exec ")))
+    (run-ruby (concat exec-prefix "zeus console") "zeus")))
 
 ;;;###autoload
 (defun inf-ruby-console-rails (dir)


### PR DESCRIPTION
When a `.zeus.sock` file is present in the current directory this means
that the project uses [zeus](https://github.com/burke/zeus) and would be
suited to use it to launch a console. Depending on if zeus is installed
globally or for the current project only this might require `bundle
exec` to run.

I think it would be a nice addition as it is already supported by `rake.el` 
for example and makes launching a console so much faster.