### PR TITLE
Changed jruby rvm prompt

### DIFF
--- a/inf-ruby.el
+++ b/inf-ruby.el
@@ -118,7 +118,7 @@ Currently only affects `inf-ruby-console-rails'."
       "\\(^(byebug) *\\)"                 ; byebug
       "\\(^\\(irb([^)]+)"                 ; IRB default
       "\\([[0-9]+] \\)?[Pp]ry ?([^)]+)"   ; Pry
-      "\\(jruby-\\|JRUBY-\\)?[1-9]\\.[0-9]\\.[0-9]+\\(-?p?[0-9]+\\)?" ; RVM
+      "\\(jruby-\\|JRUBY-\\)?[1-9]\\.[0-9]\\.[0-9]+\\.?[0-9]? ?\\([:-]?p?[0-9]+\\)? "; RVM
       "^rbx-head\\)")                     ; RVM continued
     "\\|")
    ;; Statement and nesting counters, common to the last four.


### PR DESCRIPTION
Because of the changes in the rvm jruby prompt, comint commands like 'comint-previous-input' are failing with this error message:
`Search failed: "\\(^>> *\\)\\|\\(^(rdb:1) *\\)\\|\\(^(byebug) *\\)\\|\\(^\\(irb([^)]+)\\|\\([[0-9]+] \\)?[Pp]ry ?([^)]+)\\|\\(jruby-\\|JRUBY-\\)?[1-9]\\.[0-9]\\.[0-9]+\\(-?p?[0-9]+\\)?\\|^rbx-head\\) ?[0-9:]* ?> *\\)`

The latest rvm shows this prompt (the extra .0 in the version string along with a colon ':'):
`jruby-9.0.0.0 :008 >`

This commit tries to fix this without affecting earlier prompts.