### PR TITLE
Improve inf-ruby-console-rails-p

### DIFF
--- a/inf-ruby.el
+++ b/inf-ruby.el
@@ -776,8 +776,7 @@ automatically."
     (funcall fun dir)))
 
 (defun inf-ruby-console-rails-p ()
-  (and (file-exists-p "Gemfile.lock")
-       (inf-ruby-file-contents-match "Gemfile.lock" "^ +railties ")
+  (and (file-exists-p "bin/rails")
        (file-exists-p "config/application.rb")
        (inf-ruby-file-contents-match "config/application.rb"
                                      "\\_<Rails::Application\\_>")))


### PR DESCRIPTION
Remove the requirements depending on the existance and location of a
Gemfile.lock file, as these prevent the proper operation of inf-ruby
when the Gemfile.lock is elsewhere, or Bundler is not in use.

Instead, use the existance of bin/rails, as this is something that the
Rails tooling itself depends on, and therefore more likely to be both
indicative of Rails being used, and required, as Rails is difficult to
use without it.