### PR TITLE
Add ruby-send-{buffer,line}-and-go commands

### DIFF
--- a/inf-ruby.el
+++ b/inf-ruby.el
@@ -571,12 +571,26 @@ Then switch to the process buffer."
     (widen)
     (ruby-send-region (point-min) (point-max))))
 
+(defun ruby-send-buffer-and-go ()
+  "Send the current buffer to the inferior Ruby process.
+Then switch to the process buffer."
+  (interactive)
+  (ruby-send-buffer)
+  (ruby-switch-to-inf t))
+
 (defun ruby-send-line ()
   "Send the current line to the inferior Ruby process."
   (interactive)
   (save-restriction
     (widen)
     (ruby-send-region (point-at-bol) (point-at-eol))))
+
+(defun ruby-send-line-and-go ()
+  "Send the current line to the inferior Ruby process.
+Then switch to the process buffer."
+  (interactive)
+  (ruby-send-line)
+  (ruby-switch-to-inf t))
 
 (defun ruby-escape-single-quoted (str)
   "Escape single quotes, double quotes and newlines in STR."


### PR DESCRIPTION
There are commands for sending and switching to the process buffer for blocks,
definitions and regions. This commit adds such commands for buffers and lines.