### PR TITLE
Add `ansi-color-process-output` to comint output functions

### DIFF
--- a/inf-ruby.el
+++ b/inf-ruby.el
@@ -272,6 +272,7 @@ The following commands are available:
     (set (make-local-variable 'smie-backward-token-function)
          #'inf-ruby-smie--backward-token))
   (add-hook 'comint-output-filter-functions 'inf-ruby-output-filter nil t)
+  (add-hook 'comint-output-filter-functions 'ansi-color-process-output nil t)
   (setq comint-get-old-input 'inf-ruby-get-old-input)
   (set (make-local-variable 'compilation-error-regexp-alist)
        inf-ruby-error-regexp-alist)


### PR DESCRIPTION
Rails by default show the SQL logging information with ANSI colors [`config.colorize_logging` (default to `true`)](https://guides.rubyonrails.org/configuring.html#rails-general-configuration).

`ansi-color-process-output` is autoloaded, and is also used by other comint modes, for instance `python-inferior-mode`.