### PR TITLE
Resolve deprecation warnings on inf-ruby-console-rails

### DIFF
--- a/inf-ruby.el
+++ b/inf-ruby.el
@@ -829,7 +829,7 @@ automatically."
          (with-bundler (file-exists-p "Gemfile")))
     (inf-ruby-console-run
      (concat (when with-bundler "bundle exec ")
-             "rails console "
+             "rails console -e "
              env)
      "rails")))
 


### PR DESCRIPTION
This commit resolves deprecation warnings like below:

>DEPRECATION WARNING: Passing the environment's name as
a regular argument is deprecated and will be removed
in the next Rails version. Please, use the -e option instead.

cf. https://github.com/rails/rails/pull/29358