### PR TITLE
Revert "Add `ansi-color-process-output` to comint output functions"

### DIFF
--- a/inf-ruby.el
+++ b/inf-ruby.el
@@ -272,7 +272,6 @@ The following commands are available:
     (set (make-local-variable 'smie-backward-token-function)
          #'inf-ruby-smie--backward-token))
   (add-hook 'comint-output-filter-functions 'inf-ruby-output-filter nil t)
-  (add-hook 'comint-output-filter-functions 'ansi-color-process-output nil t)
   (setq comint-get-old-input 'inf-ruby-get-old-input)
   (set (make-local-variable 'compilation-error-regexp-alist)
        inf-ruby-error-regexp-alist)


### PR DESCRIPTION
Reverts nonsequitur/inf-ruby#118

Ansi color is already applied in the global value of `comint-output-filter-functions`.