### PR TITLE
Do not use obsolete name

### DIFF
--- a/inf-ruby.el
+++ b/inf-ruby.el
@@ -556,7 +556,7 @@ Must not contain ruby meta characters.")
 (defun ruby-send-last-sexp (&optional print)
   "Send the previous sexp to the inferior Ruby process."
   (interactive "P")
-  (ruby-send-region (save-excursion (ruby-backward-sexp) (point)) (point))
+  (ruby-send-region (save-excursion (backward-sexp) (point)) (point))
   (when print (ruby-print-result)))
 
 (defun ruby-send-block (&optional print)


### PR DESCRIPTION
‘ruby-backward-sexp’ is an obsolete function (as of 28.1); use ‘backward-sexp’ instead.