### PR TITLE
Fix load-current-ruby-file in buffers that are not directly on LOAD_PATH (e.g. in subdirectory)

### DIFF
--- a/inf-ruby.el
+++ b/inf-ruby.el
@@ -783,7 +783,7 @@ Then switch to the process buffer."
 (defun ruby-load-current-file ()
   "Load the current ruby file into the inferior Ruby process."
   (interactive)
-  (ruby-load-file (buffer-name)))
+  (ruby-load-file (buffer-file-name)))
 
 (defun ruby-send-buffer ()
   "Send the current buffer to the inferior Ruby process."


### PR DESCRIPTION
## Fix broken behavior on load-current-ruby-file fn

### What?
Previously we have released a new fn called `ruby-load-current-file` using the `buffer-name` fn to retrieve the current buffer and using it to the internal `ruby-load-file`, but recently I've noticed that it didn't work with nested paths for example: 
- It works to load a file on the root `app/foo.rb` because it gets the buffer name that coincides with the file path.
- It does not work when we try to load `app/bar/foo.rb` because it sends only `foo.rb` to inferior process instead of `bar/foo.rb`

### Why?
Since usually, we work with nested paths we need to fix that, otherwise, this `ruby-load-current-file` fn will work only to load files based on the root directory. 

### How?
Well I do not have such large knowledge with Elisp but looking around I've found the [buffer-file-name](url) that seems appropriate to work with nested paths, but I'm open to suggestions to other approaches to solve that.