### PR TITLE
fix ruby-print-result for pry

### DIFF
--- a/inf-ruby.el
+++ b/inf-ruby.el
@@ -663,7 +663,7 @@ This function also removes itself from `pre-command-hook'."
                        (looking-at inf-ruby-first-prompt-pattern)))
         (accept-process-output proc))
       (re-search-backward inf-ruby-prompt-pattern)
-      (or (re-search-forward " => " (car comint-last-prompt) t)
+      (or (re-search-forward "=> " (car comint-last-prompt) t)
           ;; Evaluation seems to have failed.
           ;; Try to extract the error string.
           (let* ((inhibit-field-text-motion t)

--- a/inf-ruby.el
+++ b/inf-ruby.el
@@ -663,7 +663,7 @@ This function also removes itself from `pre-command-hook'."
                        (looking-at inf-ruby-first-prompt-pattern)))
         (accept-process-output proc))
       (re-search-backward inf-ruby-prompt-pattern)
-      (or (re-search-forward "=> " (car comint-last-prompt) t)
+      (or (re-search-forward "[ \n]=> " (car comint-last-prompt) t)
           ;; Evaluation seems to have failed.
           ;; Try to extract the error string.
           (let* ((inhibit-field-text-motion t)


### PR DESCRIPTION
In `ruby-print-result-value` it searches for " => " to find the result. That is what irb prints:
```
3.2.2 :001 > 2 + 2
 => 4 
```
But pry doesn't include the leading space:
```
[1] pry(main)> 2 + 2                                                                                    
=> 4
```
I simply removed the leading space from the search pattern and just had it search for "=> ", so it works with pry also