### PR TITLE
Ignore warnings in `irb -v` output

### DIFF
--- a/inf-ruby.el
+++ b/inf-ruby.el
@@ -110,10 +110,10 @@ returns a string."
     command))
 
 (defun inf-ruby--irb-needs-nomultiline-p (&optional with-bundler)
-  (let* ((output (shell-command-to-string
-                  (concat
-                   (when with-bundler "bundle exec ")
-                   "irb -v")))
+  (let* ((output (car (last (apply #'process-lines
+                                   (append
+                                    (when with-bundler '("bundle" "exec"))
+                                    '("irb" "-v"))))))
          (fields (split-string output "[ (]")))
     (if (equal (car fields) "irb")
         (version<= "1.2.0" (nth 1 fields))


### PR DESCRIPTION
Currently `irb -v` on my system outputs a bunch of warnings to stderr before outputting the version to stdout:

```
$ irb -v
Ignoring argon2-2.3.0 because its extensions are not built. Try: gem pristine argon2 --version 2.3.0
[...]
irb 1.12.0 (2024-03-06)
```

which makes starting `inf-ruby` fail with "if: Irb version unknown: ...". Admittedly I should repair my local ruby installation to get rid of these warnings, but I'd like `inf-ruby` (and `robe`) to work nevertheless.

Ignoring all output but the last line like this fixes it for me. Simply adding `2>/dev/null` works as well, but might create compatibility problems with Windows? In any case, please have a critical look at the elisp in this PR, since I'm not 100% confident in it.