### PR TITLE
Handle Rails 8.1 prompt

### DIFF
--- a/inf-ruby.el
+++ b/inf-ruby.el
@@ -165,7 +165,7 @@ commands as `ruby-send-last-stmt' or `ruby-switch-to-inf'."
       "\\(^(rdb:1) *\\)"                  ; Debugger
       "\\(^(rdbg[^)]*) *\\)"              ; Ruby Debug Gem
       "\\(^(byebug) *\\)"                 ; byebug
-      "\\(^[a-z0-9-_]+([a-z0-9-_]+)%s *\\)" ; Rails 7+: project name and environment
+      "\\(^[a-z0-9-_]+([a-z0-9-_]+)[0-9:]*%s *\\)" ; Rails 7+: project name and environment
       "\\(^\\(irb([^)]+)"                 ; IRB default
       "\\([[0-9]+] \\)?[Pp]ry ?([^)]+)"   ; Pry
       "\\(jruby-\\|JRUBY-\\)?[1-9]\\.[0-9]\\(\\.[0-9]+\\)*\\(-?p?[0-9]+\\)?" ; RVM


### PR DESCRIPTION
Rails 8.1 added line numbers to the IRB prompt[^1], making our prompt regex not match. That breaks commands like `comint-previous-input`. To resolve, I added an optional line number matcher so that the regex works for both Rails 7.0/8.0 (no line numbers) as well as Rails 8.1.

[^1]: https://github.com/rails/rails/commit/56982eecaf338f852c13191e7681773e6ec01164